### PR TITLE
Remove listed license files (LICENSE) from copyright

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -20,22 +20,3 @@ License: GPL-2+
  .
  On Debian systems, the complete text of the GNU General
  Public License version 2 can be found in "/usr/share/common-licenses/GPL-2".
-
-Files: LICENSE
-Copyright: Free Software Foundation, Inc., <http:fsf.org/>
-License: GPL-2
- This package is free software; you can redistribute it and/or modify
- it under the terms of the GNU General Public License as published by
- the Free Software Foundation; either version 2 of the License, or
- (at your option) any later version.
- .
- This package is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
- .
- You should have received a copy of the GNU General Public License
- along with this program. If not, see <http://www.gnu.org/licenses/>
- .
- On Debian systems, the complete text of the GNU General
- Public License version 2 can be found in "/usr/share/common-licenses/GPL-2".


### PR DESCRIPTION

Remove listed license files (LICENSE) from copyright. ([license-file-listed-in-debian-copyright](https://lintian.debian.org/tags/license-file-listed-in-debian-copyright))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes). For more information, including instructions on how to disable these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts or close the merge proposal when all changes are applied through other means (e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at https://janitor.debian.net/lintian-fixes/pkg/todo.txt-gtd/91b27ca5-ce5c-48f4-b994-1e0a073f8e0d.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/91b27ca5-ce5c-48f4-b994-1e0a073f8e0d/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/91b27ca5-ce5c-48f4-b994-1e0a073f8e0d/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/91b27ca5-ce5c-48f4-b994-1e0a073f8e0d/diffoscope)).
